### PR TITLE
Fix fast-xml-parser usage and avoid double-decoding XML entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "commander": "^2.19.0",
     "fast-xml-parser": "^4.0.8",
-    "he": "^1.2.0",
     "lodash": "^4.17.11",
     "request": "^2.88.0"
   },

--- a/src/oai-pmh-xml.js
+++ b/src/oai-pmh-xml.js
@@ -1,35 +1,31 @@
 const { get } = require('lodash')
-const parser = require('fast-xml-parser')
+const { XMLParser } = require('fast-xml-parser')
 const { decode } = require('he')
 
 const { OaiPmhError } = require('./errors')
 
-function decodeHtmlEntities(obj) {
-  if (typeof obj === 'number' || typeof obj === 'boolean') return obj;
-  if (typeof obj === 'string') return decode(obj);
+const options = {
+  attributeNamePrefix: '',
+  attrNodeName: '$',
+  textNodeName: '_',
+  ignoreAttributes: false,
+  ignoreNameSpace: false,
+  allowBooleanAttributes: false,
+  // parseFooValue controls whether fxp parses strings into numbers.
+  // We generally prefer to control that ourselves. 
+  parseNodeValue: false,
+  parseTagValue: false,
+  parseAttributeValue: false,
+  trimValues: true,
+  stopNodes: ['article-title', 'abstract', 'body'],
+  // Let fast-xml-parser handle decoding HTML character entities.
+  htmlEntities: true,
+};
+const parser = new XMLParser(options);
 
-  for (const key of Object.keys(obj)) {
-    obj[key] = decodeHtmlEntities(obj[key])
-  }
-  return obj;
-}
 
 async function parseUsingFastParser(xml) {
-  const options = {
-    attributeNamePrefix: '',
-    attrNodeName: '$',
-    textNodeName: '_',
-    ignoreAttributes: false,
-    ignoreNameSpace: false,
-    allowBooleanAttributes: false,
-    parseNodeValue: false,
-    parseAttributeValue: false,
-    trimValues: true,
-    stopNodes: ['article-title', 'abstract', 'body'],
-    htmlEntities: true,
-  };
-
-  const parsedItem = parser.parse(xml, options);
+  const parsedItem = parser.parse(xml);
 
   const oaiPmh = parsedItem && parsedItem['OAI-PMH'];
 
@@ -38,12 +34,11 @@ async function parseUsingFastParser(xml) {
   }
 
   const { error } = oaiPmh;
-  // test if the parsed xml contains an error
   if (error) {
     throw new OaiPmhError(`OAI-PMH provider returned an error: ${error._}`, get(error, '$.code'));
   }
 
-  return decodeHtmlEntities(oaiPmh);
+  return oaiPmh;
 }
 
 async function parseOaiPmhXml(xml) {

--- a/src/oai-pmh-xml.js
+++ b/src/oai-pmh-xml.js
@@ -1,6 +1,5 @@
 const { get } = require('lodash')
 const { XMLParser } = require('fast-xml-parser')
-const { decode } = require('he')
 
 const { OaiPmhError } = require('./errors')
 

--- a/src/oai-pmh-xml.js
+++ b/src/oai-pmh-xml.js
@@ -12,17 +12,16 @@ const options = {
   ignoreNameSpace: false,
   allowBooleanAttributes: false,
   // parseFooValue controls whether fxp parses strings into numbers.
-  // We generally prefer to control that ourselves. 
+  // Callers generally prefer to be able to handle that as needed. 
   parseNodeValue: false,
   parseTagValue: false,
   parseAttributeValue: false,
   trimValues: true,
   stopNodes: ['article-title', 'abstract', 'body'],
-  // Let fast-xml-parser handle decoding HTML character entities.
-  htmlEntities: true,
+  // fast-xml-parser handles decoding XML entities.
+  processEntities: true,
 };
 const parser = new XMLParser(options);
-
 
 async function parseUsingFastParser(xml) {
   const parsedItem = parser.parse(xml);

--- a/src/oai-pmh.test.js
+++ b/src/oai-pmh.test.js
@@ -33,6 +33,14 @@ describe('OaiPmh', () => {
       const res = await oaiPmh.getRecord('oai:arXiv.org:1412.8544', 'arXiv')
       res.should.containDeep(record)
     })
+
+    it('should single decode entities', async () => {
+      const oaiPmh = new OaiPmh(arxivBaseUrl)
+      const res = await oaiPmh.getRecord('oai:arXiv.org:1412.8544', 'arXiv')
+      // Simple verification of entity processing: '&amp;' becomes '&', but
+      // &amp;amp; becomes '&amp;' (to make sure we're not double-decoding).
+      res.header.identifier.should.match(/& &amp; < >/)
+    })
   })
 
   describe('identify()', () => {
@@ -151,26 +159,26 @@ describe('OaiPmh', () => {
     })
   })
 
-  describe('listRecords()', function () {
-    // the first request to arxiv always fails with 503 and a
-    // "retry after 20 seconds" message (which is OAI-PMH-compliant)
-    this.timeout(30000)
+  // describe('listRecords()', function () {
+  //   // the first request to arxiv always fails with 503 and a
+  //   // "retry after 20 seconds" message (which is OAI-PMH-compliant)
+  //   this.timeout(30000)
 
-    it('should list identifiers from arxiv', async () => {
-      const oaiPmh = new OaiPmh(arxivBaseUrl)
-      const options = {
-        metadataPrefix: 'arXiv',
-        from: '2015-01-01',
-        until: '2015-01-03'
-      }
-      const res = []
-      for await (const record of oaiPmh.listRecords(options)) {
-        res.push(record)
-      }
-      res.should.containDeep([record])
-      res.should.have.length(2)
-    })
-  })
+  //   it('should list identifiers from arxiv', async () => {
+  //     const oaiPmh = new OaiPmh(arxivBaseUrl)
+  //     const options = {
+  //       metadataPrefix: 'arXiv',
+  //       from: '2015-01-01',
+  //       until: '2015-01-03'
+  //     }
+  //     const res = []
+  //     for await (const record of oaiPmh.listRecords(options)) {
+  //       res.push(record)
+  //     }
+  //     res.should.containDeep([record])
+  //     res.should.have.length(2)
+  //   })
+  // })
 
   describe('listSets()', () => {
     it('should list arxiv sets', async () => {

--- a/src/oai-pmh.test.js
+++ b/src/oai-pmh.test.js
@@ -159,26 +159,26 @@ describe('OaiPmh', () => {
     })
   })
 
-  // describe('listRecords()', function () {
-  //   // the first request to arxiv always fails with 503 and a
-  //   // "retry after 20 seconds" message (which is OAI-PMH-compliant)
-  //   this.timeout(30000)
+  describe('listRecords()', function () {
+    // the first request to arxiv always fails with 503 and a
+    // "retry after 20 seconds" message (which is OAI-PMH-compliant)
+    this.timeout(30000)
 
-  //   it('should list identifiers from arxiv', async () => {
-  //     const oaiPmh = new OaiPmh(arxivBaseUrl)
-  //     const options = {
-  //       metadataPrefix: 'arXiv',
-  //       from: '2015-01-01',
-  //       until: '2015-01-03'
-  //     }
-  //     const res = []
-  //     for await (const record of oaiPmh.listRecords(options)) {
-  //       res.push(record)
-  //     }
-  //     res.should.containDeep([record])
-  //     res.should.have.length(2)
-  //   })
-  // })
+    it('should list identifiers from arxiv', async () => {
+      const oaiPmh = new OaiPmh(arxivBaseUrl)
+      const options = {
+        metadataPrefix: 'arXiv',
+        from: '2015-01-01',
+        until: '2015-01-03'
+      }
+      const res = []
+      for await (const record of oaiPmh.listRecords(options)) {
+        res.push(record)
+      }
+      res.should.containDeep([record])
+      res.should.have.length(2)
+    })
+  })
 
   describe('listSets()', () => {
     it('should list arxiv sets', async () => {

--- a/test/nock-fixtures/oaipmh-getrecord---should-single-decode-entities.json
+++ b/test/nock-fixtures/oaipmh-getrecord---should-single-decode-entities.json
@@ -1,0 +1,24 @@
+[
+    {
+        "scope": "http://export.arxiv.org:80",
+        "method": "GET",
+        "path": "/oai2?verb=GetRecord&identifier=oai%3AarXiv.org%3A1412.8544&metadataPrefix=arXiv",
+        "body": "",
+        "status": 200,
+        "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<OAI-PMH xmlns=\"http://www.openarchives.org/OAI/2.0/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd\">\n<responseDate>2018-06-21T14:30:12Z</responseDate>\n<request verb=\"GetRecord\" identifier=\"oai:arXiv.org:1412.8544\" metadataPrefix=\"arXiv\">http://export.arxiv.org/oai2</request>\n<GetRecord>\n<record>\n<header>\n <identifier>&amp; &amp;amp; &lt; &gt;</identifier></header></record></GetRecord></xml>\n",
+        "rawHeaders": [
+            "Date",
+            "Thu, 21 Jun 2018 14:30:10 GMT",
+            "Server",
+            "Apache",
+            "Vary",
+            "Accept-Encoding,User-Agent",
+            "Connection",
+            "close",
+            "Transfer-Encoding",
+            "chunked",
+            "Content-Type",
+            "text/xml"
+        ]
+    }
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -869,11 +869,6 @@ eslint@~5.4.0:
     table "^4.0.3"
     text-table "^0.2.0"
 
-esm@^3.2.4:
-  version "3.2.25"
-  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
-  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
-
 espree@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-4.1.0.tgz#728d5451e0fd156c04384a7ad89ed51ff54eb25f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1218,7 +1218,7 @@ hasha@^3.0.0:
   dependencies:
     is-stream "^1.0.1"
 
-he@1.2.0, he@^1.2.0:
+he@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==


### PR DESCRIPTION
Note: I'm still not super confident in my machine setup, so I'd appreciate someone checking out this branch to verify my work.

This PR does three things:

1. Update our usage of fast-xml-parser to align with the 4.x usage, by instantiating the exported class with the appropriate options.
2. Explicitly sets the parseTagValue option to false, to make sure we don't zealously turn numeric tag values into integers. (This is important, because otherwise it wants to turn arxiv IDs into decimal numbers 😅 )
3. Removes the extra layer of manual entity decoding, confirming with a unit test that we now only decode entities once.